### PR TITLE
Fix docker build error because of missing arm64 chromium dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
-FROM node:latest
+FROM arm64v8/node:latest
 
-RUN apt-get update \
-  && apt-get install -y wget gnupg \
-  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-  && apt update \
-  && apt install -y google-chrome-stable \
-                    fonts-ipafont-gothic \
-                    fonts-wqy-zenhei \
-                    fonts-thai-tlwg \
-                    fonts-kacst \
-                    fonts-freefont-ttf libxss1 \
-                    bash --no-install-recommends
-COPY . /root/yt_rec_graph
-WORKDIR /root/yt_rec_graph
-RUN yarn
-EXPOSE 38472/tcp
-EXPOSE 38478/tcp
-EXPOSE 38479/tcp
+RUN apt update
+RUN apt upgrade -y
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+RUN apt-get update && \
+    apt-get install -y wget gnupg && \
+    apt-get install -y fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf libxss1 \
+        libgtk2.0-0 libnss3 libatk-bridge2.0-0 libdrm2 libxkbcommon0 libgbm1 libasound2 && \
+    apt-get install -y chromium && \
+    apt-get clean
+
+RUN apt install libnss3 \
+                libatk1.0-0 \
+                libatk-bridge2.0-0 \
+                libcups2 \
+                libdrm2 \
+                libxkbcommon0 \
+                libxcomposite1 \


### PR DESCRIPTION
Changed dockerfile to install chromium separately and use that version for puppeteer.